### PR TITLE
bat is a less alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ If you want to contribute, please read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### System tools
 
-#### cat
+#### less
 
-* [bat](https://github.com/sharkdp/bat) - A cat(1) clone with wings.
+* [bat](https://github.com/sharkdp/bat) - `less` with syntax highlighting and speed
 
 #### [cloc](https://github.com/AlDanial/cloc)
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ If you want to contribute, please read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### System tools
 
-#### less
-
-* [bat](https://github.com/sharkdp/bat) - `less` with syntax highlighting and speed
-
 #### [cloc](https://github.com/AlDanial/cloc)
 
 * [tokei](https://github.com/XAMPPRocky/tokei) - Count your code, quickly.
@@ -57,6 +53,10 @@ If you want to contribute, please read [CONTRIBUTING.md](CONTRIBUTING.md).
 #### hexdump
 
 * [hexyl](https://github.com/sharkdp/hexyl) - A command-line hex viewer
+
+#### less
+
+* [bat](https://github.com/sharkdp/bat) - `less` with syntax highlighting and speed
 
 #### ls
 


### PR DESCRIPTION
`cat` reads files to stdout, `less` and `bat` are for interactive viewing

I know `bat` claims to be a `cat` alternative, but... please... 🥺