### PR TITLE
Add xh as httpie alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 * [bottom](https://github.com/ClementTsang/bottom) - Yet another cross-platform graphical process/system monitor.
 * [ytop](https://github.com/cjbassi/ytop) (no longer maintained) - A TUI system monitor written in Rust
 
+#### [httpie](https://httpie.io/)
+
+* [xh](https://github.com/ducaale/xh) - Friendly and fast tool for sending HTTP requests
+
 ### Terminal
 
 #### [tmux](https://github.com/tmux/tmux)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 * [hexyl](https://github.com/sharkdp/hexyl) - A command-line hex viewer
 
+#### [httpie](https://github.com/httpie/httpie)
+
+* [xh](https://github.com/ducaale/xh) - Friendly and fast tool for sending HTTP requests
+
 #### ls
 
 * [exa](https://github.com/ogham/exa) - A replacement for 'ls'
@@ -117,10 +121,6 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 * [bottom](https://github.com/ClementTsang/bottom) - Yet another cross-platform graphical process/system monitor.
 * [ytop](https://github.com/cjbassi/ytop) (no longer maintained) - A TUI system monitor written in Rust
-
-#### [httpie](https://github.com/httpie/httpie)
-
-* [xh](https://github.com/ducaale/xh) - Friendly and fast tool for sending HTTP requests
 
 ### Terminal
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 * [bottom](https://github.com/ClementTsang/bottom) - Yet another cross-platform graphical process/system monitor.
 * [ytop](https://github.com/cjbassi/ytop) (no longer maintained) - A TUI system monitor written in Rust
 
-#### [httpie](https://httpie.io/)
+#### [httpie](https://github.com/httpie/httpie)
 
 * [xh](https://github.com/ducaale/xh) - Friendly and fast tool for sending HTTP requests
 


### PR DESCRIPTION
> HTTPie is a user-friendly command-line HTTP client for the API era.

> xh is a friendly and fast tool for sending HTTP requests. It reimplements as much as possible of HTTPie's excellent design.

[![asciicast](https://github.com/ducaale/xh/raw/master/assets/xh-demo.gif)](https://asciinema.org/a/390748)