### PR TITLE
Add `oreboot`, a Rust rewrite of `coreboot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 * [loc](https://github.com/cgag/loc) - Count lines of code quickly.
 * [tokei](https://github.com/XAMPPRocky/tokei) - Count your code, quickly.
 
+#### [coreboot](https://github.com/coreboot/coreboot)
+
+* [oreboot](https://github.com/oreboot/oreboot) - oreboot is a fork of coreboot, with C removed, written in Rust. 
+
 #### cut
 
 * [choose](https://github.com/theryangeary/choose) - A human-friendly and fast alternative to cut and (sometimes) awk


### PR DESCRIPTION
Thank you for building this fantastic list! I was in need of a RIIR compilation so this will be a great resource to refer back to.

changelog:
 - List [oreboot](https://github.com/oreboot/oreboot) as an alternative to it's C-written counterpart [coreboot](https://github.com/coreboot/coreboot)