### PR TITLE
Add `Lemmy` and `libreddit` to new Web category

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
   - [Text editors](#text-editors)
   - [Text processing](#text-processing)
   - [Utilities](#utilities)
+  - [Web](#web)
 - [Development tools](#development-tools)
   - [Command runners](#command-runners)
   - [Linters](#linters)
@@ -161,6 +162,16 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 #### [lazygit](https://github.com/jesseduffield/lazygit)
 
 * [gitui](https://github.com/extrawurst/gitui) - Blazing fast terminal-ui for git written in Rust 🦀
+
+### Web
+
+#### [Reddit](https://www.reddit.com/)
+
+* [Lemmy](https://github.com/LemmyNet/lemmy) - 🐀 Building a federated alternative to reddit in rust 
+
+#### [teddit](https://codeberg.org/teddit/teddit)
+
+* [libreddit](https://github.com/spikecodes/libreddit) - Private front-end for Reddit written in Rust 
 
 ## Development tools
 


### PR DESCRIPTION
Disclaimer: I'm the maintainer of Libreddit

changelog:
- Add "Web" category
- Add [Lemmy](https://github.com/LemmyNet/lemmy), a Reddit clone in Rust
- Add [libreddit](https://github.com/spikecodes/libreddit), a Reddit front-end in Rust
