### PR TITLE
Add `drill`, an http load testing application

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 - [Applications](#applications)
   - [Container](#container)
+  - [Performance](#performance)
   - [System tools](#system-tools)
   - [Terminal](#terminal)
   - [Text editors](#text-editors)
@@ -28,6 +29,12 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 #### [runc](https://github.com/opencontainers/runc)
 
 * [youki](https://github.com/utam0k/youki) - An experimental container runtime written in Rust
+
+### Performance
+
+#### [jMeter](https://github.com/apache/jmeter)
+
+* [drill](https://github.com/fcsonline/drill) - A HTTP load testing application written in Rust
 
 ### System tools
 

--- a/README.md
+++ b/README.md
@@ -194,11 +194,11 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 #### [Reddit](https://www.reddit.com/)
 
-* [Lemmy](https://github.com/LemmyNet/lemmy) - 🐀 Building a federated alternative to reddit in rust 
+* [Lemmy](https://github.com/LemmyNet/lemmy) - 🐀 Building a federated alternative to reddit in rust
 
 #### [teddit](https://codeberg.org/teddit/teddit)
 
-* [libreddit](https://github.com/spikecodes/libreddit) - Private front-end for Reddit written in Rust 
+* [libreddit](https://github.com/spikecodes/libreddit) - Private front-end for Reddit written in Rust
 
 ## Development tools
 


### PR DESCRIPTION
changelog: Add `drill`, an HTTP load testing application

An alternative to HTTP performance applications like jMeter.