### PR TITLE
Add `swc` compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 * [just](https://github.com/casey/just) - A command runner and partial replacement for `make`
 
+### Compilers
+
+#### [TypeScript Compiler](https://github.com/microsoft/TypeScript)
+
+* [swc](https://github.com/swc-project/swc) - swc is a super-fast compiler written in rust
+
 ### Linters
 
 #### [ESLint](https://github.com/eslint/eslint)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
   - [Web](#web)
 - [Development tools](#development-tools)
   - [Command runners](#command-runners)
+  - [Compilers](#compilers)
   - [Linters](#linters)
 
 ## Applications


### PR DESCRIPTION
changelog:
 - Add compilers category
 - Add [swc](https://github.com/swc-project/swc), a TypeScript/JavaScript compiler written in Rust

Closes #78 