### PR TITLE
Add ion shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 #### bash/PowerShell/fish
 
-* [nushell](https://github.com/nushell/nushell/) - An attractive structured shell
 * [ion](https://github.com/redox-os/ion) - A modern shell developed for RedoxOS. But is still capable on \*nix platforms.
+* [nushell](https://github.com/nushell/nushell/) - An attractive structured shell
 
 #### bc
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 #### bash/PowerShell/fish
 
 * [nushell](https://github.com/nushell/nushell/) - An attractive structured shell
+* [ion](https://github.com/redox-os/ion) - A modern shell developed for RedoxOS. But is still capable on \*nix platforms.
 
 #### bc
 


### PR DESCRIPTION

---

changelog: Added ion as an alternative shell. While it is developed for RedoxOS, and used in it as the default, ion is easily installed on *nix platforms with cargo install, or even from the repos.
