### PR TITLE
add zenith to htop alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 #### top
 
 * [bottom](https://github.com/ClementTsang/bottom) - Yet another cross-platform graphical process/system monitor.
+* [zenith](https://github.com/bvaisvil/zenith) - Option to zoom in and out
 * [ytop](https://github.com/cjbassi/ytop) (no longer maintained) - A TUI system monitor written in Rust
+
 
 #### uniq
 


### PR DESCRIPTION
Zenith is an amazing and well-maintained alternative to htop