### PR TITLE
Add `pls` and drop `exa`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 #### ls
 
-* [eza](github.com/eza-community/eza) - A modern, maintained replacement for ls
+* [eza](https://github.com/eza-community/eza) - A modern, maintained replacement for ls
 * [lsd](https://github.com/lsd-rs/lsd) - An ls with a lot of pretty colors and awesome icons
 * [pls](https://github.com/pls-rs/pls) - `pls` is a prettier and powerful `ls(1)` for the pros.
 * [nat](https://github.com/willdoescode/nat) - `ls` alternative with useful info and a splash of color 🎨

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 #### ls
 
+* [eza](github.com/eza-community/eza) - A modern, maintained replacement for ls
 * [lsd](https://github.com/lsd-rs/lsd) - An ls with a lot of pretty colors and awesome icons
 * [pls](https://github.com/pls-rs/pls) - `pls` is a prettier and powerful `ls(1)` for the pros.
 * [nat](https://github.com/willdoescode/nat) - `ls` alternative with useful info and a splash of color 🎨

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 #### ls
 
-* [exa](https://github.com/ogham/exa) - A replacement for 'ls'
 * [lsd](https://github.com/lsd-rs/lsd) - An ls with a lot of pretty colors and awesome icons
+* [pls](https://github.com/pls-rs/pls) - `pls` is a prettier and powerful `ls(1)` for the pros.
 * [nat](https://github.com/willdoescode/nat) - `ls` alternative with useful info and a splash of color 🎨
 
 #### [nvm](https://github.com/nvm-sh/nvm)


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: Adds `pls`, a new `ls` alternative, and drops `exa` as it has been deprecated.
