### PR TITLE
Add `dqy` alternative to `dig`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 #### dig
 
 * [dog](https://github.com/ogham/dog) - A command-line DNS client.
+* [dqy](https://github.com/dandyvica/dqy) - A DNS query tool inspired by `dig`, `drill`, and `dog`.
 
 #### du
 


### PR DESCRIPTION
As mentioned in https://github.com/TaKO8Ki/awesome-alternatives-in-rust/issues/118, `dog` is abandoned. Thus @dandyvica created a new tool as an alternative to both `dig` and `dog.`


