### PR TITLE
Add Anima — Claude Code companion (Tauri v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 #### [Spaceship](https://github.com/spaceship-prompt/spaceship-prompt)
 
-* [starship](https://github.com/starship/starship) - ☄️🌌 The minimal, blazing-fast, and infinitely customizable prompt for any shell!
+* [starship](https://github.com/starship/starship) - ☄🌌 The minimal, blazing-fast, and infinitely customizable prompt for any shell!
 
 #### [termite](https://github.com/thestinger/termite)
 
@@ -221,6 +221,10 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 * [ripgrep](https://github.com/BurntSushi/ripgrep) - ripgrep recursively searches directories for a regex pattern while respecting your gitignore
 
 ### Utilities
+
+#### Claude Code /buddy
+
+* [Anima](https://github.com/btangonan/anima) - A native macOS companion for Claude Code with per-project ASCII familiars, nim token economy, and cross-session watcher. Built with Tauri v2.
 
 #### [codemod](https://github.com/facebookarchive/codemod)
 


### PR DESCRIPTION
Anima is a native macOS app I built to extend Claude Code's /buddy companion system.

When Anthropic launched /buddy, I loved the idea but wanted more: per-project companions instead of one per account, a way to earn and unlock new ones, and the ability to actually use buddy observations in my Claude Code sessions.

So I built it. Every project gets its own ASCII companion (8 species, 5 rarity tiers, 80 unique combos), token usage earns in-app currency for re-rolls, and a Rust daemon polls all active sessions to surface observations about your work.

Tauri v2 + Rust backend + vanilla JS frontend. 4MB binary. 43 tests. MIT licensed. First app I've ever shipped.

https://github.com/btangonan/anima